### PR TITLE
Two bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "chai-string": "^1.1.2",
     "mocha": "^2.2.1",
     "mocha-loader": "^0.7.1",
-    "promise": "^7.0.4",
     "sinon": "^1.15.4",
     "sinon-chai": "^2.8.0"
   },
@@ -34,6 +33,7 @@
     "dockerode": "^2.2.2",
     "dockerode-promise": "^0.1.0",
     "lodash": "^3.10.1",
+    "promise": "^7.0.4",
     "qretry": "^0.3.0",
     "through": "^2.3.8",
     "winston": "^1.0.1"

--- a/test/docker-container.integration.spec.js
+++ b/test/docker-container.integration.spec.js
@@ -19,17 +19,16 @@ describe("the docker driver", function() {
 
         let killContainer = () => {
             if (!process.env.TRAVIS) {
-                return () => container.kill()
-                            .then(() => expect(() => container._docker.getContainer(container._container.id)).to.throw);
+                return container.kill()
+                  .then(() => expect(() => container._docker.getContainer(container._container.id)).to.throw);
             } else {
                 return Promise.resolve();
             }
-        }
+        };
 
         return container.run({env: {"SOMEVAR": "someValue"}})
             .then(() => retry(() => container.logs().then(log => expect(log).to.contain('Hello from Docker.'))))
-            .then(killContainer);
-        ;
+            .then(killContainer, killContainer);
     });
 
 });


### PR DESCRIPTION
Fix #1: the 'promise' dependency should not be declared in 'devDependencies', because it's used in production code.
Fix#2: the integration test did not properly clean up after itself, because killContainer should return a Promise and not a function that returns a promise (killContainer is the function that returns the Promise to mocha in this case)